### PR TITLE
Feature: use epoch seconds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ repositories {
 dependencies {
     api 'javax.servlet:javax.servlet-api:3.1.0'
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.8+'
+    testImplementation 'org.powermock:powermock-module-junit4:1.7+'
+    testImplementation 'org.powermock:powermock-api-mockito2:1.7+'
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }
 

--- a/src/main/java/com/jossemargt/cookietwist/tornado/TornadoCookieValue.java
+++ b/src/main/java/com/jossemargt/cookietwist/tornado/TornadoCookieValue.java
@@ -173,6 +173,7 @@ public final class TornadoCookieValue {
          *            a Date instance that holds the UNIX epoch timestamp
          * @return the builder
          */
+        @Deprecated
         public TornadoCookieValueBuilder withTimestamp(Date timestamp) {
             this.timestamp = timestamp.getTime();
             return this;

--- a/src/main/java/com/jossemargt/cookietwist/tornado/transform/TornadoCookieCodec.java
+++ b/src/main/java/com/jossemargt/cookietwist/tornado/transform/TornadoCookieCodec.java
@@ -24,7 +24,7 @@
 package com.jossemargt.cookietwist.tornado.transform;
 
 import java.security.InvalidKeyException;
-import java.util.Date;
+import java.time.Instant;
 
 import javax.servlet.http.Cookie;
 
@@ -171,7 +171,7 @@ public abstract class TornadoCookieCodec {
      */
     private long getTimestamp() {
         if (timestamp == TIMESTAMP_NOW) {
-            return new Date().getTime();
+            return Instant.now().getEpochSecond();
         }
 
         return timestamp;

--- a/src/test/java/com/jossemargt/cookietwist/bugs/github6/TornadoCookieCodecTest.java
+++ b/src/test/java/com/jossemargt/cookietwist/bugs/github6/TornadoCookieCodecTest.java
@@ -1,0 +1,65 @@
+package com.jossemargt.cookietwist.bugs.github6;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.security.InvalidKeyException;
+import java.time.Instant;
+
+import javax.servlet.http.Cookie;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.jossemargt.cookietwist.tornado.transform.TornadoCookieCodec;
+import com.jossemargt.cookietwist.tornado.transform.impl.V1TornadoCookieCodec;
+import com.jossemargt.cookietwist.tornado.transform.impl.V2TornadoCookieCodec;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({ "javax.crypto.*" })
+@PrepareForTest(TornadoCookieCodec.class)
+public class TornadoCookieCodecTest {
+
+    private static String secretKey = "not-so-secret";
+    private static long frozenTimestamp = 1521518443;
+    private static Instant frozenInstant;
+    private static TornadoCookieCodec v1Subject;
+    private static TornadoCookieCodec v2Subject;
+
+    @BeforeClass
+    public static void setUpAll() throws InvalidKeyException {
+        frozenInstant = Instant.ofEpochSecond(frozenTimestamp);
+        v1Subject = V1TornadoCookieCodec.builder().withSecretKey(secretKey).build();
+        v2Subject = V2TornadoCookieCodec.builder().withSecretKey(secretKey).build();
+    }
+
+    @Before
+    public void setUp() {
+        mockStatic(Instant.class);
+        when(Instant.now()).thenReturn(frozenInstant);
+    }
+
+    @Test
+    public void testV1TornadoCookieCodecTimestamp() throws InvalidKeyException {
+        String expectedV1TornadoCookieValue = "value|1521518443|8d2c562f3831063fbc70cd0b35da54aa4e4e730e";
+
+        Cookie signedCookie = v1Subject.encodeCookie(new Cookie("name", "value"));
+
+        assertEquals(expectedV1TornadoCookieValue, signedCookie.getValue());
+    }
+
+    @Test
+    public void testV2TornadoCookieCodecTimestamp() throws InvalidKeyException {
+        String expectedV2TornadoCookieValue = "2|1:0|10:1521518443|4:name|8:dmFsdWU=|80d021ad66d8ff3187d95a9203890d7c7bf7da0b995c54671203729b6f467961";
+
+        Cookie signedCookie = v2Subject.encodeCookie(new Cookie("name", "value"));
+
+        assertEquals(expectedV2TornadoCookieValue, signedCookie.getValue());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I'm changing the timestamp generation logic in TornadoCookieCode class, that uses `Instant.now().getEpochSeconds()` instead of `new Date().getTime()`, since the latter one returns the epoch time in milliseconds. I had to add [Mockito](https://github.com/mockito/mockito) and [PowerMock](https://github.com/powermock/powermock) in order to get a [fixed Instant instance](https://github.com/powermock/powermock/wiki/Mock-System) and verify the final TornadoCookieValue string representation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here by using the `closes #xxx` pattern. -->
This PR should fix #6 . Where the desired Tornado secure cookie value should contain a timestamp in epoch seconds instead of milliseconds.

## Change type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [x] My code follows the project's code style (checkstyle gradle's plugin was in peace with my changes).
- [x] I have updated the documentation accordingly (at least javadoc comments).
