### PR TITLE
Synchronize signature hasher engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.8+'
     testImplementation 'org.powermock:powermock-module-junit4:1.7+'
     testImplementation 'org.powermock:powermock-api-mockito2:1.7+'
+    testImplementation 'net.jodah:concurrentunit:0.4.+'
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }
 

--- a/src/main/java/com/jossemargt/cookietwist/signature/SignatureHasher.java
+++ b/src/main/java/com/jossemargt/cookietwist/signature/SignatureHasher.java
@@ -42,6 +42,9 @@ public abstract class SignatureHasher {
     /** The hasher instance from {@link Mac}. */
     protected Mac hasher;
 
+    /** The initialized variable flags the hasher instance state. **/
+    protected boolean initialized = false;
+
     /**
      * Instantiates a new signature hasher with a secret key String and a
      * un-initialized {@link Mac} instance.
@@ -64,11 +67,21 @@ public abstract class SignatureHasher {
      * @return the formatted hexadecimal string
      */
     public String computeSignature(String... values) {
-        for (String v : values) {
-            hasher.update(v.getBytes(StandardCharsets.UTF_8));
+        if (!initialized) {
+            throw new IllegalStateException("Un-initialized signature hasher");
         }
 
-        return toHexString(hasher.doFinal());
+        byte[] result;
+
+        synchronized (hasher) {
+            for (String v : values) {
+                hasher.update(v.getBytes(StandardCharsets.UTF_8));
+            }
+
+            result = hasher.doFinal();
+        }
+
+        return toHexString(result);
     }
 
     /**

--- a/src/main/java/com/jossemargt/cookietwist/signature/impl/Sha1SignatureHasher.java
+++ b/src/main/java/com/jossemargt/cookietwist/signature/impl/Sha1SignatureHasher.java
@@ -68,6 +68,7 @@ public class Sha1SignatureHasher extends SignatureHasher {
             e.printStackTrace();
         } finally {
             hasher.init(signingKey);
+            this.initialized = true;
         }
     }
 

--- a/src/main/java/com/jossemargt/cookietwist/signature/impl/Sha256SignatureHasher.java
+++ b/src/main/java/com/jossemargt/cookietwist/signature/impl/Sha256SignatureHasher.java
@@ -68,6 +68,7 @@ public class Sha256SignatureHasher extends SignatureHasher {
             e.printStackTrace();
         } finally {
             hasher.init(signingKey);
+            this.initialized = true;
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I changed the `computeSignature` method to ` syncronized`, locking the whole instance when the method is called.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since one of the library intentions is to have a single `TornadoCookieCodec` instance per application context it needs to handle multi thread scenarios. Unfortunately the ` SignatureHasher`  contains a mutable hasher engine that fully relies on its state, because of this the synchronize modifier was added to the intrinsic parts where it is modified.


## Change type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [x] My code follows the project's code style (checkstyle gradle's plugin was in peace with my changes).
- [x] I have updated the documentation accordingly (at least javadoc comments).
